### PR TITLE
Wordpress image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+./example/db_data
+./example/wordpress

--- a/db/README.md
+++ b/db/README.md
@@ -1,4 +1,4 @@
-##Prerequisites for creating Aurora DB
+## Prerequisites for creating Aurora DB
 ### Create a VPC and Subnets
 You can only create an Amazon Aurora DB cluster in a Virtual Private Cloud (VPC) that spans two Availability Zones, and each zone must contain at least one subnet. You can create an Aurora DB cluster in the default VPC for your AWS account, or you can create a user-defined VPC.
 

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,75 @@
+##Prerequisites for creating Aurora DB
+### Create a VPC and Subnets
+You can only create an Amazon Aurora DB cluster in a Virtual Private Cloud (VPC) that spans two Availability Zones, and each zone must contain at least one subnet. You can create an Aurora DB cluster in the default VPC for your AWS account, or you can create a user-defined VPC.
+
+We will create a VPC which spans two AZs and each AZ will have a subnet.
+#### Create a VPC using console
+
+##### VPC Dashboard->Start VPC Wizard->VPC with a Single Public Subnet
+##### Set the following rules
+- IP CIDR block: 10.0.0.0/16
+- VPC name: gs-cluster-vpc
+- Public subnet: 10.0.0.0/24
+- Availability Zone: ap-southeast-2a
+- Subnet name: gs-subnet-public-a
+- Enable DNS hostnames: Yes
+- Hardware tenancy: Default 
+##### Add additional subnets
+VPC Dashboard -> Subnets -> Create subnet
+- name tag: gs-subnet-public-b
+- VPC: gs-cluster-vpc
+- Availability Zone: ap-southeast-2b
+- CIDR block: 10.0.10.0/24
+
+same way to create *gs-subnet-private-a(10.0.1.0/24)* and *gs-subnet-private-b(10.0.11.0/24)*
+Note: make sure the 2nd subnet use the same route table as the first one.
+
+### Create a Security Group and Add Inbound Rules
+VPC Dashboard -> Security Groups -> Create Security Group
+- Name tag: gs-securitygroup1
+- Group name: gs-securitygroup1
+- Description: Getting Started Security Group
+- VPC: gs-cluster-vpc
+
+#### Inbound rules
+All Trafffic, All Protocal, All Port range, source(0.0.0.0/0 only works for testing environment, in producation should only allow a public ip to access the db instance, use https://checkip.amazonaws.com to determine your public IP)
+
+
+### Create a DB Subnet Group
+The last thing that you need before you can create an Aurora DB cluster is a DB subnet group. Your DB subnet group identifies the subnets that your DB cluster uses from the VPC that you created in the previous steps. Your DB subnet group must include at least one subnet in at least two of the Availability Zones in the AWS Region where you want to deploy your DB cluster.
+
+rds ->subnet groups -> Create DB Subnet group
+- Name:gs-subnetgroup
+- Description: Getting Started Subnet Group
+- VPC Id:gs-cluster-vpc
+
+Choose *Add all the subnets related to this VPC*
+
+## Creating a DB Cluster and Connecting to a Database on an Aurora MySQL DB Cluster
+Amazon RDS -> Databases ->  Create database 
+- Engine type: Amazon Aurora
+- Edition: Amazon Aurora with MySQL 5.6 compatibility
+- DB instance size:  Dev/Test
+- DB cluster identifier: database-1
+- Master username: admin
+- Password: admin12345
+- Create database
+
+To connect to the DB instance as the master user, use the user name and password that appear.
+
+Depending on the DB instance class and the amount of storage, it can take up to 20 minutes before the new DB cluster is available.
+
+## Connect to an Instance in a DB Cluster
+Choose *Databases* and then choose the DB cluster name to show its details. On the *Connectivity & security* tab, copy the value for the *Endpoint name* of the *Writer* endpoint. Also, note the *port number* for the endpoint.
+
+Use the cluster endpoint to connect to the primary instance, and the master user name that you created previously. (You are prompted for a password.) If you supplied a port value other than 3306, use that for the -P parameter instead.
+```
+mysql -h <cluster endpoint> -P 3306 -u <mymasteruser> -p						
+````
+
+
+
+
+
+Reference （https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_GettingStartedAurora.CreatingConnecting.Aurora.html）
+

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,39 @@
+# Run wordpress
+This provides a good example start to test run wordpress locally from wordpress image.
+
+## How to
+
+Make sure you have installed [docker-compose](https://docs.docker.com/compose/install/) in your local machine.
+
+Then run in this example directory run
+```docker-compose up```
+
+and it will pull and run a wordpress image and a mysql image, after a few seconds, you can access 
+```localhost:8000``` to setup your local wordpress website
+
+## Volume
+
+Within docker-compose.yaml, tt's worth to noting the **volumes** attribute for db and wordpress service.
+```
+ volumes:
+       - ./db_data:/var/lib/mysql:rw      
+```
+and
+```
+  volumes: 
+       - ./wordpress:/var/www/html:rw
+```
+
+What them do is mount a container path(**/var/lib/mysql** for db,**/var/www/html** for wordpress) to your local machine, so after you delete your container, the data will be saved.
+
+After the website up and running, you will see there are two folders created within this **example** folder, one is **db_data** and another **wordpress**, try to make some changes to the wordpress, for example, add one more theme, and you will see one more theme folder shows within **wordpress/wp-content/themes**
+
+There are three types of volumes in docker.
+- Host volumes
+- Anonymous volumes
+- Named volumes
+
+What we used in this docker-compose.yml is host volumes.
+
+
+

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.3'
+
+services:
+   db:
+     image: mysql:5.7
+     volumes:
+       - ./db_data:/var/lib/mysql:rw
+     restart: always
+     environment:
+       MYSQL_ROOT_PASSWORD: somewordpress
+       MYSQL_DATABASE: wordpress
+       MYSQL_USER: wordpress
+       MYSQL_PASSWORD: wordpress
+
+   wordpress:
+     depends_on:
+       - db
+     image: wordpress:php7.3-apache
+     volumes: 
+       - ./wordpress:/var/www/html:rw
+     ports:
+       - "8000:80"
+     restart: always
+     environment:
+       WORDPRESS_DB_HOST: db:3306
+       WORDPRESS_DB_USER: wordpress
+       WORDPRESS_DB_PASSWORD: wordpress
+       WORDPRESS_DB_NAME: wordpress

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -8,16 +8,16 @@ Repository name:ad/wordpress
 #### Retrieve an authentication token and authenticate your Docker client to your registry
 Use the AWS CLI:
 
-aws ecr get-login-password --region ap-southeast-2 | docker login --username AWS --password-stdin 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress
+```aws ecr get-login-password --region ap-southeast-2 | docker login --username AWS --password-stdin 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress```
 
 
 #### Build your Docker image using the following command. For information on building a Docker file from scratch see the instructions here . You can skip this step if your image is already built:
 
-docker build -t ad/wordpress .
+```docker build -t ad/wordpress .```
 
 #### After the build completes, tag your image so you can push the image to this repository:
-docker tag wordpress:latest 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress:latest
+```docker tag wordpress:latest 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress:latest```
 
 #### Run the following command to push this image to your newly created AWS repository:
-docker push 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress:latest
+```docker push 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress:latest```
 

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -20,3 +20,4 @@ docker tag wordpress:latest 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad
 
 #### Run the following command to push this image to your newly created AWS repository:
 docker push 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress:latest
+

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -1,0 +1,22 @@
+## Build and Push wordpress image to AWS ECR
+### Create an ECR Repository
+Login to the AWS console and navigate to 
+ECR ->  Create repository -> Enable Tag Immutability -> Confirm creation
+Repository name:ad/wordpress
+
+### Push to AWS ECR 
+#### Retrieve an authentication token and authenticate your Docker client to your registry
+Use the AWS CLI:
+
+aws ecr get-login-password --region ap-southeast-2 | docker login --username AWS --password-stdin 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress
+
+
+#### Build your Docker image using the following command. For information on building a Docker file from scratch see the instructions here . You can skip this step if your image is already built:
+
+docker build -t ad/wordpress .
+
+#### After the build completes, tag your image so you can push the image to this repository:
+docker tag wordpress:latest 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress:latest
+
+#### Run the following command to push this image to your newly created AWS repository:
+docker push 607961847144.dkr.ecr.ap-southeast-2.amazonaws.com/ad/wordpress:latest

--- a/wordpress/docker-compose.yml
+++ b/wordpress/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.3'
+
+services:
+   db:
+     image: mysql:5.7
+     volumes:
+       - db_data:/var/lib/mysql
+     restart: always
+     environment:
+       MYSQL_ROOT_PASSWORD: somewordpress
+       MYSQL_DATABASE: wordpress
+       MYSQL_USER: wordpress
+       MYSQL_PASSWORD: wordpress
+
+   wordpress:
+     depends_on:
+       - db
+     image: wordpress:latest
+     ports:
+       - "8000:80"
+     restart: always
+     environment:
+       WORDPRESS_DB_HOST: db:3306
+       WORDPRESS_DB_USER: wordpress
+       WORDPRESS_DB_PASSWORD: wordpress
+       WORDPRESS_DB_NAME: wordpress
+volumes:
+    db_data: {}

--- a/wordpress/docker-compose.yml
+++ b/wordpress/docker-compose.yml
@@ -1,28 +1,19 @@
 version: '3.3'
 
 services:
-   db:
-     image: mysql:5.7
-     volumes:
-       - db_data:/var/lib/mysql
-     restart: always
-     environment:
-       MYSQL_ROOT_PASSWORD: somewordpress
-       MYSQL_DATABASE: wordpress
-       MYSQL_USER: wordpress
-       MYSQL_PASSWORD: wordpress
-
    wordpress:
      depends_on:
        - db
-     image: wordpress:latest
+     image: wordpress:php7.3-apache
+     volumes: 
+       - wordpress:/var/www/html:rw
      ports:
        - "8000:80"
      restart: always
-     environment:
-       WORDPRESS_DB_HOST: db:3306
+     environment: # environment variable will changed when connecting aws rds
+       WORDPRESS_DB_HOST: db:3306 
        WORDPRESS_DB_USER: wordpress
        WORDPRESS_DB_PASSWORD: wordpress
        WORDPRESS_DB_NAME: wordpress
 volumes:
-    db_data: {}
+   wordpress: {} #this need to be change when mount to aws persistent storage


### PR DESCRIPTION
- Create a docker-compose.yml that configure a Wordpress website by pulling a Wordpress image and MySQL image. Run ```docker compose up``` will start the Wordpress server.
- Tested by pushing the image to ECR, so the Wordpress image can be used to create instances in ECS.
- The steps of pushing the image to ECR has been provided in README.