### PR TITLE
create terraform code for aurora db

### DIFF
--- a/terraform/_provider.tf
+++ b/terraform/_provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-southeast-2"
+}

--- a/terraform/db/README.md
+++ b/terraform/db/README.md
@@ -1,0 +1,75 @@
+## Prerequisites for creating Aurora DB
+### Create a VPC and Subnets
+You can only create an Amazon Aurora DB cluster in a Virtual Private Cloud (VPC) that spans two Availability Zones, and each zone must contain at least one subnet. You can create an Aurora DB cluster in the default VPC for your AWS account, or you can create a user-defined VPC.
+
+We will create a VPC which spans two AZs and each AZ will have a subnet.
+#### Create a VPC using console
+
+##### VPC Dashboard->Start VPC Wizard->VPC with a Single Public Subnet
+##### Set the following rules
+- IP CIDR block: 10.0.0.0/16
+- VPC name: gs-cluster-vpc
+- Public subnet: 10.0.0.0/24
+- Availability Zone: ap-southeast-2a
+- Subnet name: gs-subnet-public-a
+- Enable DNS hostnames: Yes
+- Hardware tenancy: Default 
+##### Add additional subnets
+VPC Dashboard -> Subnets -> Create subnet
+- name tag: gs-subnet-public-b
+- VPC: gs-cluster-vpc
+- Availability Zone: ap-southeast-2b
+- CIDR block: 10.0.10.0/24
+
+same way to create *gs-subnet-private-a(10.0.1.0/24)* and *gs-subnet-private-b(10.0.11.0/24)*
+Note: make sure the 2nd subnet use the same route table as the first one.
+
+### Create a Security Group and Add Inbound Rules
+VPC Dashboard -> Security Groups -> Create Security Group
+- Name tag: gs-securitygroup1
+- Group name: gs-securitygroup1
+- Description: Getting Started Security Group
+- VPC: gs-cluster-vpc
+
+#### Inbound rules
+All Trafffic, All Protocal, All Port range, source(0.0.0.0/0 only works for testing environment, in producation should only allow a public ip to access the db instance, use https://checkip.amazonaws.com to determine your public IP)
+
+
+### Create a DB Subnet Group
+The last thing that you need before you can create an Aurora DB cluster is a DB subnet group. Your DB subnet group identifies the subnets that your DB cluster uses from the VPC that you created in the previous steps. Your DB subnet group must include at least one subnet in at least two of the Availability Zones in the AWS Region where you want to deploy your DB cluster.
+
+rds ->subnet groups -> Create DB Subnet group
+- Name:gs-subnetgroup
+- Description: Getting Started Subnet Group
+- VPC Id:gs-cluster-vpc
+
+Choose *Add all the subnets related to this VPC*
+
+## Creating a DB Cluster and Connecting to a Database on an Aurora MySQL DB Cluster
+Amazon RDS -> Databases ->  Create database 
+- Engine type: Amazon Aurora
+- Edition: Amazon Aurora with MySQL 5.6 compatibility
+- DB instance size:  Dev/Test
+- DB cluster identifier: database-1
+- Master username: admin
+- Password: admin12345
+- Create database
+
+To connect to the DB instance as the master user, use the user name and password that appear.
+
+Depending on the DB instance class and the amount of storage, it can take up to 20 minutes before the new DB cluster is available.
+
+## Connect to an Instance in a DB Cluster
+Choose *Databases* and then choose the DB cluster name to show its details. On the *Connectivity & security* tab, copy the value for the *Endpoint name* of the *Writer* endpoint. Also, note the *port number* for the endpoint.
+
+Use the cluster endpoint to connect to the primary instance, and the master user name that you created previously. (You are prompted for a password.) If you supplied a port value other than 3306, use that for the -P parameter instead.
+```
+mysql -h <cluster endpoint> -P 3306 -u <mymasteruser> -p						
+````
+
+
+
+
+
+Reference （https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_GettingStartedAurora.CreatingConnecting.Aurora.html）
+

--- a/terraform/db/README.md
+++ b/terraform/db/README.md
@@ -1,4 +1,4 @@
-## Prerequisites for creating Aurora DB
+##Prerequisites for creating Aurora DB
 ### Create a VPC and Subnets
 You can only create an Amazon Aurora DB cluster in a Virtual Private Cloud (VPC) that spans two Availability Zones, and each zone must contain at least one subnet. You can create an Aurora DB cluster in the default VPC for your AWS account, or you can create a user-defined VPC.
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,16 @@
+
+module "vpc" {
+  source  = "./vpc"
+  # public_subnets = var.public_subnets
+  # region = var.region
+  # private_subnets = var.private_subnets
+  # vpc_cidr = var.vpc_cidr
+  # availability_zones = var.availability_zones
+
+}
+
+module "rds" {
+  source  = "./rds"
+  vpc_id = module.vpc.vpc_id
+  db_subnet_group_name = module.vpc.subnet_group_name
+}

--- a/terraform/rds/README.md
+++ b/terraform/rds/README.md
@@ -1,9 +1,13 @@
-##Prerequisites for creating Aurora DB
-### Create a VPC and Subnets
-You can only create an Amazon Aurora DB cluster in a Virtual Private Cloud (VPC) that spans two Availability Zones, and each zone must contain at least one subnet. You can create an Aurora DB cluster in the default VPC for your AWS account, or you can create a user-defined VPC.
+## Aurora db 
+The rds.tf provides example code for creating a aurora db cluster and instances.
+
+###Prerequisites for creating Aurora DB
+#### Create a VPC and Subnets
+You can only create an Amazon Aurora DB cluster in a Virtual Private Cloud (VPC) that spans two Availability Zones, and each zone must contain at least one subnet. And the rds needs to be deployed to private subnet, so the instance won't be access externally. For this rds.tf, it is expecting vpc and subnet group from other module. VPC module will output vpc id and a subnet group which contains two private subnets.
 
 We will create a VPC which spans two AZs and each AZ will have a subnet.
 #### Create a VPC using console
+This is an example of how to create vpc and subnets in aws console.
 
 ##### VPC Dashboard->Start VPC Wizard->VPC with a Single Public Subnet
 ##### Set the following rules
@@ -24,7 +28,7 @@ VPC Dashboard -> Subnets -> Create subnet
 same way to create *gs-subnet-private-a(10.0.1.0/24)* and *gs-subnet-private-b(10.0.11.0/24)*
 Note: make sure the 2nd subnet use the same route table as the first one.
 
-### Create a Security Group and Add Inbound Rules
+#### Create a Security Group and Add Inbound Rules
 VPC Dashboard -> Security Groups -> Create Security Group
 - Name tag: gs-securitygroup1
 - Group name: gs-securitygroup1
@@ -35,7 +39,7 @@ VPC Dashboard -> Security Groups -> Create Security Group
 All Trafffic, All Protocal, All Port range, source(0.0.0.0/0 only works for testing environment, in producation should only allow a public ip to access the db instance, use https://checkip.amazonaws.com to determine your public IP)
 
 
-### Create a DB Subnet Group
+#### Create a DB Subnet Group
 The last thing that you need before you can create an Aurora DB cluster is a DB subnet group. Your DB subnet group identifies the subnets that your DB cluster uses from the VPC that you created in the previous steps. Your DB subnet group must include at least one subnet in at least two of the Availability Zones in the AWS Region where you want to deploy your DB cluster.
 
 rds ->subnet groups -> Create DB Subnet group
@@ -45,7 +49,8 @@ rds ->subnet groups -> Create DB Subnet group
 
 Choose *Add all the subnets related to this VPC*
 
-## Creating a DB Cluster and Connecting to a Database on an Aurora MySQL DB Cluster
+### Creating a DB Cluster and Connecting to a Database on an Aurora MySQL DB Cluster
+
 Amazon RDS -> Databases ->  Create database 
 - Engine type: Amazon Aurora
 - Edition: Amazon Aurora with MySQL 5.6 compatibility
@@ -59,7 +64,7 @@ To connect to the DB instance as the master user, use the user name and password
 
 Depending on the DB instance class and the amount of storage, it can take up to 20 minutes before the new DB cluster is available.
 
-## Connect to an Instance in a DB Cluster
+### Connect to an Instance in a DB Cluster
 Choose *Databases* and then choose the DB cluster name to show its details. On the *Connectivity & security* tab, copy the value for the *Endpoint name* of the *Writer* endpoint. Also, note the *port number* for the endpoint.
 
 Use the cluster endpoint to connect to the primary instance, and the master user name that you created previously. (You are prompted for a password.) If you supplied a port value other than 3306, use that for the -P parameter instead.

--- a/terraform/rds/README.md
+++ b/terraform/rds/README.md
@@ -1,7 +1,7 @@
 ## Aurora db 
 The rds.tf provides example code for creating a aurora db cluster and instances.
 
-###Prerequisites for creating Aurora DB
+### Prerequisites for creating Aurora DB
 #### Create a VPC and Subnets
 You can only create an Amazon Aurora DB cluster in a Virtual Private Cloud (VPC) that spans two Availability Zones, and each zone must contain at least one subnet. And the rds needs to be deployed to private subnet, so the instance won't be access externally. For this rds.tf, it is expecting vpc and subnet group from other module. VPC module will output vpc id and a subnet group which contains two private subnets.
 

--- a/terraform/rds/README.md
+++ b/terraform/rds/README.md
@@ -1,7 +1,10 @@
+## Prerequisites for creating Aurora DB
+### Create a VPC and Subnets
+You can only create an Amazon Aurora DB cluster in a Virtual Private Cloud (VPC) that spans two Availability Zones, and each zone must contain at least one subnet. You can create an Aurora DB cluster in the default VPC for your AWS account, or you can create a user-defined VPC.
 ## Aurora db 
 The rds.tf provides example code for creating a aurora db cluster and instances.
 
-###Prerequisites for creating Aurora DB
+### Prerequisites for creating Aurora DB
 #### Create a VPC and Subnets
 You can only create an Amazon Aurora DB cluster in a Virtual Private Cloud (VPC) that spans two Availability Zones, and each zone must contain at least one subnet. And the rds needs to be deployed to private subnet, so the instance won't be access externally. For this rds.tf, it is expecting vpc and subnet group from other module. VPC module will output vpc id and a subnet group which contains two private subnets.
 
@@ -11,70 +14,40 @@ This is an example of how to create vpc and subnets in aws console.
 
 ##### VPC Dashboard->Start VPC Wizard->VPC with a Single Public Subnet
 ##### Set the following rules
-- IP CIDR block: 10.0.0.0/16
-- VPC name: gs-cluster-vpc
-- Public subnet: 10.0.0.0/24
-- Availability Zone: ap-southeast-2a
-- Subnet name: gs-subnet-public-a
-- Enable DNS hostnames: Yes
-- Hardware tenancy: Default 
-##### Add additional subnets
-VPC Dashboard -> Subnets -> Create subnet
-- name tag: gs-subnet-public-b
-- VPC: gs-cluster-vpc
-- Availability Zone: ap-southeast-2b
-- CIDR block: 10.0.10.0/24
-
+@@ -24,7 +28,7 @@ VPC Dashboard -> Subnets -> Create subnet
 same way to create *gs-subnet-private-a(10.0.1.0/24)* and *gs-subnet-private-b(10.0.11.0/24)*
 Note: make sure the 2nd subnet use the same route table as the first one.
 
+### Create a Security Group and Add Inbound Rules
 #### Create a Security Group and Add Inbound Rules
 VPC Dashboard -> Security Groups -> Create Security Group
 - Name tag: gs-securitygroup1
 - Group name: gs-securitygroup1
-- Description: Getting Started Security Group
-- VPC: gs-cluster-vpc
-
-#### Inbound rules
+@@ -35,7 +39,7 @@ VPC Dashboard -> Security Groups -> Create Security Group
 All Trafffic, All Protocal, All Port range, source(0.0.0.0/0 only works for testing environment, in producation should only allow a public ip to access the db instance, use https://checkip.amazonaws.com to determine your public IP)
 
 
+### Create a DB Subnet Group
 #### Create a DB Subnet Group
 The last thing that you need before you can create an Aurora DB cluster is a DB subnet group. Your DB subnet group identifies the subnets that your DB cluster uses from the VPC that you created in the previous steps. Your DB subnet group must include at least one subnet in at least two of the Availability Zones in the AWS Region where you want to deploy your DB cluster.
 
 rds ->subnet groups -> Create DB Subnet group
-- Name:gs-subnetgroup
-- Description: Getting Started Subnet Group
-- VPC Id:gs-cluster-vpc
+@@ -45,7 +49,8 @@ rds ->subnet groups -> Create DB Subnet group
 
 Choose *Add all the subnets related to this VPC*
 
+## Creating a DB Cluster and Connecting to a Database on an Aurora MySQL DB Cluster
 ### Creating a DB Cluster and Connecting to a Database on an Aurora MySQL DB Cluster
 
 Amazon RDS -> Databases ->  Create database 
 - Engine type: Amazon Aurora
 - Edition: Amazon Aurora with MySQL 5.6 compatibility
-- DB instance size:  Dev/Test
-- DB cluster identifier: database-1
-- Master username: admin
-- Password: admin12345
-- Create database
-
-To connect to the DB instance as the master user, use the user name and password that appear.
+@@ -59,7 +64,7 @@ To connect to the DB instance as the master user, use the user name and password
 
 Depending on the DB instance class and the amount of storage, it can take up to 20 minutes before the new DB cluster is available.
 
+## Connect to an Instance in a DB Cluster
 ### Connect to an Instance in a DB Cluster
 Choose *Databases* and then choose the DB cluster name to show its details. On the *Connectivity & security* tab, copy the value for the *Endpoint name* of the *Writer* endpoint. Also, note the *port number* for the endpoint.
 
 Use the cluster endpoint to connect to the primary instance, and the master user name that you created previously. (You are prompted for a password.) If you supplied a port value other than 3306, use that for the -P parameter instead.
-```
-mysql -h <cluster endpoint> -P 3306 -u <mymasteruser> -p						
-````
-
-
-
-
-
-Reference （https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_GettingStartedAurora.CreatingConnecting.Aurora.html）
-

--- a/terraform/rds/rds.tf
+++ b/terraform/rds/rds.tf
@@ -1,0 +1,48 @@
+resource "aws_rds_cluster" "rdsclu" {
+    cluster_identifier      = var.cluster_name
+    engine                  = "aurora-mysql"
+    engine_version          = "5.7.mysql_aurora.2.07.2"
+    db_subnet_group_name    = var.db_subnet_group_name
+    vpc_security_group_ids  = [aws_security_group.rds-apps.id]
+    availability_zones      = var.availability_zones
+    database_name           = var.db_name
+    master_username         = "admin"
+    master_password         = "admin" # the password will be repalced when security manager set up
+    backup_retention_period = 1
+    deletion_protection     = false
+    apply_immediately       = true
+    skip_final_snapshot     = true
+}
+
+resource "aws_rds_cluster_instance" "cluster_instances" {
+    count                  = 1
+    identifier             = "aurora-cluster-instance"
+    cluster_identifier     = aws_rds_cluster.rdsclu.id
+    instance_class         = "db.r4.large" # this is the smallest instance can be use for the engine
+    engine                 = "aurora-mysql"
+    engine_version         = "5.7.mysql_aurora.2.07.2" #serverless is not supported for this version 
+    db_subnet_group_name   = var.db_subnet_group_name
+}
+
+
+resource "aws_security_group" "rds-apps" {
+    name   = var.db_sg_name
+    vpc_id = var.vpc_id
+
+    lifecycle {
+        create_before_destroy = true
+    }
+
+    ingress {
+        from_port       = 3306
+        to_port         = 3306
+        protocol        = "tcp"
+        #cidr_blocks = aws_vpc.main.cidr_block
+        #security_groups = [module.ecs_apps.ecs_nodes_secgrp_id] This probably will need after setting up ecs
+        description     = "From ECS Nodes"
+    }
+}
+
+output "rds_host" {
+    value = aws_rds_cluster.rdsclu.endpoint
+}

--- a/terraform/rds/rds.tf
+++ b/terraform/rds/rds.tf
@@ -1,13 +1,13 @@
 resource "aws_rds_cluster" "rdsclu" {
-    cluster_identifier      = var.cluster_name
+    cluster_identifier      = "${var.project_name}-db-cluster"
     engine                  = "aurora-mysql"
     engine_version          = "5.7.mysql_aurora.2.07.2"
     db_subnet_group_name    = var.db_subnet_group_name
     vpc_security_group_ids  = [aws_security_group.rds-apps.id]
     availability_zones      = var.availability_zones
     database_name           = var.db_name
-    master_username         = "admin"
-    master_password         = "admin" # the password will be repalced when security manager set up
+    master_username         = var.db_user_name
+    master_password         = var.db_password # the password will be repalced when security manager set up
     backup_retention_period = 1
     deletion_protection     = false
     apply_immediately       = true
@@ -16,7 +16,7 @@ resource "aws_rds_cluster" "rdsclu" {
 
 resource "aws_rds_cluster_instance" "cluster_instances" {
     count                  = 1
-    identifier             = "aurora-cluster-instance"
+    identifier             = "${var.project_name}-rds-instance"
     cluster_identifier     = aws_rds_cluster.rdsclu.id
     instance_class         = "db.r4.large" # this is the smallest instance can be use for the engine
     engine                 = "aurora-mysql"
@@ -26,7 +26,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 
 
 resource "aws_security_group" "rds-apps" {
-    name   = var.db_sg_name
+    name   = "${var.project_name}-sg"
     vpc_id = var.vpc_id
 
     lifecycle {
@@ -37,9 +37,9 @@ resource "aws_security_group" "rds-apps" {
         from_port       = 3306
         to_port         = 3306
         protocol        = "tcp"
-        #cidr_blocks = aws_vpc.main.cidr_block
+        cidr_blocks     = [var.vpc_cidr]
         #security_groups = [module.ecs_apps.ecs_nodes_secgrp_id] This probably will need after setting up ecs
-        description     = "From ECS Nodes"
+        # description     = "From ECS Nodes"
     }
 }
 

--- a/terraform/rds/variables.tf
+++ b/terraform/rds/variables.tf
@@ -1,0 +1,31 @@
+variable project_name {
+    default = "devopsacademy-project"
+    type = string
+}
+
+variable db_name {
+    default = "devopsacademyprojectdb"
+    type = string
+}
+
+variable db_sg_name {
+    default = "devopsacademy-project-db-sg"
+    type = string
+}
+variable cluster_name {
+    default = "devopsacademy-project-cluster"
+    type = string
+}
+
+variable db_subnet_group_name {
+    type = string
+}
+
+variable availability_zones {
+    type = list
+    default = ["ap-southeast-2a", "ap-southeast-2b"]
+}
+
+variable "vpc_id" {
+    type = string
+}

--- a/terraform/rds/variables.tf
+++ b/terraform/rds/variables.tf
@@ -4,9 +4,14 @@ variable project_name {
 }
 
 variable db_name {
-    default = "devopsacademyprojectdb"
+    default = "db1"
     type = string
 }
+variable vpc_cidr {
+    type = string
+    default = "10.0.0.0/16"
+}
+
 
 variable db_sg_name {
     default = "devopsacademy-project-db-sg"
@@ -28,4 +33,14 @@ variable availability_zones {
 
 variable "vpc_id" {
     type = string
+}
+
+variable "db_user_name" {
+    type = string
+    default = "admin"
+}
+
+variable "db_password" {
+    type = string
+    default = "admin123"
 }


### PR DESCRIPTION
- Create a terraform code for creating aws aurora db
- the terraform/main.tf file is used to set up the modules, it is expecting a vpc modules, the commented statements within vpc module could be replaced by the vpc modules variables.